### PR TITLE
Add fstar-mcp to devcontainer with Rust support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   // Runs only once when container is prepared
   "onCreateCommand": "",
   // Runs periodically and/or when content of repo changes
-  "updateContentCommand": "ln -s ~/pulse pulse",
+  "updateContentCommand": "ln -sf ~/FStar FStar && ln -sf ~/pulse pulse && ln -sf ~/karamel karamel && ln -sf ~/fstar-mcp fstar-mcp",
   // These run only when the container is assigned to a user
   "postCreateCommand": "",
 }

--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -5,6 +5,7 @@
 # rebuild the container (and FStar, and Pulse) everytime, which is very
 # expensive.
 
+# Base container already includes: FStar, karamel, z3, opam/OCaml
 FROM mtzguido/pulse-base-devcontainer:latest
 
 # Get Pulse and build
@@ -16,3 +17,15 @@ RUN eval $(opam env) \
  && make -j$(nproc) -C share/pulse/examples/
 
 ENV PULSE_HOME $HOME/pulse
+
+# Install Rust via rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="$HOME/.cargo/bin:$PATH"
+
+# Get fstar-mcp and build
+RUN source $HOME/.cargo/env \
+ && git clone --depth=1 https://github.com/FStarLang/fstar-mcp \
+ && cd fstar-mcp/ \
+ && cargo build --release
+
+ENV FSTAR_MCP_HOME $HOME/fstar-mcp


### PR DESCRIPTION
- Install Rust via rustup in Dockerfile
- Clone and build fstar-mcp with cargo
- Update symlinks to include FStar, pulse, karamel, and fstar-mcp

Co-authored-by: GitHub Copilot (Claude Opus)